### PR TITLE
[ch431] Adding XML support to Hermes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# hermes
-A Grails plugin with guaranteed one-time delivery capabilities for HTTP requests
+# Hermes
+Hermes is a Grails plugin providing guaranteed one-time delivery capabilities for HTTP requests.  This plugin does not
+archive sent messages or response data beyond the status code for failed messages.
+
+## Configuration
+
+Application properties:
+
+* `com.atlasgenetics.hermes.retryTimes` - Sets the maximum number of times Hermes should attempt to send a failed
+message during the retry process.  Type: `int`, default value: 5
+* `com.atlasgenetics.hermes.retryInterval` - Sets the time in milliseconds that Hermes will wait between attempts at
+making a given HTTP request during the retry process.  Type: `Long`, default value: `10000L` (10 seconds)
 
 ## This Repo
 
-This is a multi-project build for testing purposes.  The plugin itself is housed in `hermes-plugin`.  In order to
-effectively test a Grails plugin, one must create a full-fledged Grails app that installs the plugin and test it there.
-Unit tests are supported within the plugin itself, but integration tests are not.  Hence, the integration testing app is
-housed in `hermes-integration-test-app`.
-
-Please see the READMEs in their respective folders for more information and instructions.
+This is a multi-project build for testing purposes.  The plugin itself is housed in `hermes-plugin`.  Unit tests are
+in `hermes-plugin`; integration tests are in `hermes-integration-test-app`.

--- a/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageManagerServiceIntegrationSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageManagerServiceIntegrationSpec.groovy
@@ -2,13 +2,16 @@ package com.atlasgenetics.hermes.message
 
 import com.atlasgenetics.hermes.utils.RestUtils
 import grails.testing.mixin.integration.Integration
-import grails.transaction.Rollback
-import org.springframework.http.HttpMethod
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import org.springframework.http.HttpStatus
+import org.springframework.test.annotation.Rollback
+import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
 @Rollback
+@Transactional
 class FailedMessageManagerServiceIntegrationSpec extends Specification {
 
     def failedMessageManagerService
@@ -43,7 +46,8 @@ class FailedMessageManagerServiceIntegrationSpec extends Specification {
     void "test create failed message"() {
         given: "A MessageComand"
         MessageCommand command = new MessageCommand()
-        command.httpMethod = HttpMethod.GET
+        command.httpMethod = Method.GET
+        command.contentType = ContentType.JSON
         command.url = "http://www.test.example.com"
 
         and: "an HTTP status code"

--- a/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageMonitorServiceIntegrationSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageMonitorServiceIntegrationSpec.groovy
@@ -2,13 +2,9 @@ package com.atlasgenetics.hermes.message
 
 import grails.testing.mixin.integration.Integration
 import groovy.time.TimeCategory
-import org.springframework.test.annotation.Rollback
-import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
-@Rollback
-@Transactional
 class FailedMessageMonitorServiceIntegrationSpec extends Specification {
 
     FailedMessageMonitorService failedMessageMonitorService

--- a/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageMonitorServiceIntegrationSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/FailedMessageMonitorServiceIntegrationSpec.groovy
@@ -1,12 +1,14 @@
 package com.atlasgenetics.hermes.message
 
 import grails.testing.mixin.integration.Integration
-import grails.transaction.Rollback
 import groovy.time.TimeCategory
+import org.springframework.test.annotation.Rollback
+import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
 @Rollback
+@Transactional
 class FailedMessageMonitorServiceIntegrationSpec extends Specification {
 
     FailedMessageMonitorService failedMessageMonitorService

--- a/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/HermesServiceFunctionalSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/HermesServiceFunctionalSpec.groovy
@@ -1,16 +1,19 @@
 package com.atlasgenetics.hermes.message
 
-import com.stehno.ersatz.ContentType
+import com.stehno.ersatz.ContentType as ErsatzContentType
 import com.stehno.ersatz.ErsatzServer
 import grails.testing.mixin.integration.Integration
-import grails.transaction.Rollback
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import hermes.integration.test.app.utils.TestUtils
-import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.test.annotation.Rollback
+import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
 @Rollback
+@Transactional
 class HermesServiceFunctionalSpec extends Specification {
 
     def hermesService
@@ -52,7 +55,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.GET, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.GET, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams)
             session.flush()
             return out
@@ -80,7 +83,7 @@ class HermesServiceFunctionalSpec extends Specification {
             put(TEST_URI) {
                 header(TEST_HEADER_KEY, TEST_HEADER_VAL)
                 query(QUERY_PARAM_KEY, QUERY_PARAM_VAL)
-                body(TEST_BODY, ContentType.APPLICATION_JSON.value)
+                body(TEST_BODY, ErsatzContentType.APPLICATION_JSON.value)
                 responder {
                     code HttpStatus.OK.value()
                 }
@@ -98,7 +101,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.PUT, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.PUT, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams, TEST_BODY)
             session.flush()
             return out
@@ -126,7 +129,7 @@ class HermesServiceFunctionalSpec extends Specification {
             post(TEST_URI) {
                 header(TEST_HEADER_KEY, TEST_HEADER_VAL)
                 query(QUERY_PARAM_KEY, QUERY_PARAM_VAL)
-                body(TEST_BODY, ContentType.APPLICATION_JSON.value)
+                body(TEST_BODY, ErsatzContentType.APPLICATION_JSON.value)
                 responder {
                     code HttpStatus.OK.value()
                 }
@@ -144,7 +147,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.POST, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.POST, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams, TEST_BODY)
             session.flush()
             return out
@@ -189,7 +192,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.HEAD, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.HEAD, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams)
             session.flush()
             return out
@@ -234,7 +237,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.DELETE, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.DELETE, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams)
             session.flush()
             return out
@@ -279,7 +282,7 @@ class HermesServiceFunctionalSpec extends Specification {
 
         when: "we send the message"
         boolean success = FailedMessage.withSession { session ->
-            boolean out = hermesService.makeRequest(HttpMethod.GET, "$baseUrl$TEST_URI", headers,
+            boolean out = hermesService.makeRequest(Method.GET, "$baseUrl$TEST_URI", ContentType.JSON, headers,
                     queryParams)
             session.flush()
             return out

--- a/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/MessageSenderServiceIntegrationSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/com/atlasgenetics/hermes/message/MessageSenderServiceIntegrationSpec.groovy
@@ -2,14 +2,17 @@ package com.atlasgenetics.hermes.message
 
 import com.stehno.ersatz.ErsatzServer
 import grails.testing.mixin.integration.Integration
-import grails.transaction.Rollback
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import hermes.integration.test.app.utils.TestUtils
-import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.test.annotation.Rollback
+import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
 @Rollback
+@Transactional
 class MessageSenderServiceIntegrationSpec extends Specification {
 
     def messageSenderService
@@ -45,7 +48,8 @@ class MessageSenderServiceIntegrationSpec extends Specification {
         and: "the appropriate message data"
         MessageCommand cmd = new MessageCommand()
         cmd.url = "${mock.getHttpUrl()}$TEST_URI"
-        cmd.httpMethod = HttpMethod.GET
+        cmd.httpMethod = Method.GET
+        cmd.contentType = ContentType.JSON
 
         when: "we try to send the message"
         boolean sent = messageSenderService.sendMessage(cmd)
@@ -76,7 +80,8 @@ class MessageSenderServiceIntegrationSpec extends Specification {
         and: "the appropriate message data"
         MessageCommand cmd = new MessageCommand()
         cmd.url = "${mock.getHttpUrl()}$TEST_URI"
-        cmd.httpMethod = HttpMethod.GET
+        cmd.httpMethod = Method.GET
+        cmd.contentType = ContentType.JSON
 
         when: "we try to send the message"
         boolean sent = messageSenderService.sendMessage(cmd)
@@ -105,7 +110,8 @@ class MessageSenderServiceIntegrationSpec extends Specification {
         and: "the appropriate message data"
         MessageCommand cmd = new MessageCommand()
         cmd.url = "${mock.getHttpUrl()}$uri"
-        cmd.httpMethod = HttpMethod.GET
+        cmd.httpMethod = Method.GET
+        cmd.contentType = ContentType.JSON
 
         when: "we try to send the message"
         boolean sent  = FailedMessage.withSession { session ->
@@ -147,7 +153,8 @@ class MessageSenderServiceIntegrationSpec extends Specification {
         and: "the appropriate message data"
         MessageCommand cmd = new MessageCommand()
         cmd.url = "${mock.getHttpUrl()}$TEST_URI"
-        cmd.httpMethod = HttpMethod.GET
+        cmd.httpMethod = Method.GET
+        cmd.contentType = ContentType.JSON
 
         and: "the retryTimes configuration property set to override the default value"
         grailsApplication.config.com.atlasgenetics.hermes.retryTimes = 10

--- a/hermes-integration-test-app/src/integration-test/groovy/hermes/integration/test/app/SampleRetryFailedMessageJobServiceIntegrationSpec.groovy
+++ b/hermes-integration-test-app/src/integration-test/groovy/hermes/integration/test/app/SampleRetryFailedMessageJobServiceIntegrationSpec.groovy
@@ -4,15 +4,18 @@ import com.atlasgenetics.hermes.message.FailedMessage
 import com.atlasgenetics.hermes.message.MessageCommand
 import com.stehno.ersatz.ErsatzServer
 import grails.testing.mixin.integration.Integration
-import grails.transaction.Rollback
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import hermes.integration.test.app.utils.TestUtils
 import org.hibernate.engine.spi.Status
-import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.test.annotation.Rollback
+import org.springframework.transaction.annotation.Transactional
 import spock.lang.Specification
 
 @Integration
 @Rollback
+@Transactional
 class SampleRetryFailedMessageJobServiceIntegrationSpec extends Specification {
 
     def sampleRetryFailedMessageJobService
@@ -33,7 +36,8 @@ class SampleRetryFailedMessageJobServiceIntegrationSpec extends Specification {
 
         and: "a FailedMessage ready for retry containing the appropriate data"
         MessageCommand cmd = new MessageCommand()
-        cmd.httpMethod = HttpMethod.GET
+        cmd.httpMethod = Method.GET
+        cmd.contentType = ContentType.JSON
         cmd.url = "${mock.httpUrl}$TEST_URI"
 
         FailedMessage message = new FailedMessage()

--- a/hermes-plugin/README.md
+++ b/hermes-plugin/README.md
@@ -1,16 +1,6 @@
 # hermes
-A Grails plugin with guaranteed one-time delivery capabilities for HTTP requests.  This plugin does not archive sent
-messages or response data.  It does not support `PATCH` or `INDEX` requests, or multipart forms.  It does not support
-SOAP or content types other than JSON.
-
-## Install the plugin in your local Maven repo
-
-From the project root directory:
-
-`$ grails install`
-
-You should now be able to find the plugin in your `~/.m2` directory and install it as a dependency into any of your
-local Grails apps.
+A Grails plugin providing guaranteed one-time delivery capabilities for HTTP requests.  This plugin does not archive sent
+messages or response data beyond the status code for failed messages.
 
 ## Configuration
 

--- a/hermes-plugin/build.gradle
+++ b/hermes-plugin/build.gradle
@@ -53,9 +53,6 @@ dependencies {
     testCompile "org.grails:grails-plugin-testing"
     testCompile "org.grails:grails-web-testing-support"
 
-    // Grails RestBuilder plugin
-    compile 'org.grails:grails-datastore-rest-client:5.0.0.RC2'
-
     // grails HTTPBuilder plugin
     compile('org.grails.plugins:http-builder-helper:1.0.2') {
         exclude group: 'xml-apis'

--- a/hermes-plugin/build.gradle
+++ b/hermes-plugin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version "1.1"
+version "1.2"
 group "com.atlasgenetics"
 
 apply plugin:"eclipse"

--- a/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
+++ b/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
@@ -1,8 +1,9 @@
 package com.atlasgenetics.hermes.message
 
 import grails.gorm.transactions.Transactional
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import org.springframework.context.MessageSource
-import org.springframework.http.HttpMethod
 
 /**
  * This service is the entry point into Hermes for users who wish to take full advantage of its capabilities.  From
@@ -42,16 +43,18 @@ class HermesService {
      * @param httpMethod
      * @param url This can include the queryParams, or they can be included as a separate Map.  NOTE: If the queryParams
      *        are passed in as a Map, url will be put through a URL encoder as part of the queryParam encoding process
+     * @param contentType
      * @param headers
      * @param queryParams
      * @param body
      * @return true if the message was sent successfully; false if it failed
      */
-    boolean makeRequest(HttpMethod httpMethod, String url, Map<String, Object> headers = null,
+    boolean makeRequest(Method httpMethod, String url, ContentType contentType, Map<String, Object> headers = null,
                         Map<String, Object> queryParams = null, Map<String, Object> body = null) {
         MessageCommand messageCommand = new MessageCommand()
         messageCommand.httpMethod = httpMethod
         messageCommand.url = url
+        messageCommand.contentType = contentType
         messageCommand.headers = headers
         messageCommand.queryParams = queryParams
         messageCommand.body = body

--- a/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
+++ b/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
@@ -18,7 +18,7 @@ import org.springframework.context.MessageSource
  * same as any message that fails with a 5xx status.  Messages will be saved to the database with a special status code
  * (see {@link com.atlasgenetics.hermes.utils.RestUtils}), and will be eligible for retry at a later date.
  *
- * Please note that Hermes DOES NOT support PATCH requests, INDEX requests, or multipart forms.
+ * Please note that Hermes DOES NOT support multipart forms.
  *
  * Hermes DOES NOT save any response data beyond the status code.  Response bodies etc. will be ignored and discarded.
  *

--- a/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/MessageSenderService.groovy
+++ b/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/MessageSenderService.groovy
@@ -20,7 +20,6 @@ class MessageSenderService {
     private Long retryWaitTime
     private Integer maxRetryTimes
 
-
     @PostConstruct
     void init() {
         retryWaitTime = grailsApplication.config.getProperty('com.atlasgenetics.hermes.retryInterval', Long, 10000L)

--- a/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/message/MessageCommand.groovy
@@ -1,8 +1,9 @@
 package com.atlasgenetics.hermes.message
 
 import grails.validation.Validateable
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import groovyx.net.http.URIBuilder
-import org.springframework.http.HttpMethod
 
 /**
  * This Command object provides validation for message data, as well as some convenient methods.
@@ -10,14 +11,16 @@ import org.springframework.http.HttpMethod
 class MessageCommand implements Validateable {
 
     String url
-    String httpMethod
+    Method httpMethod
+    ContentType contentType
     Map<String, Object> headers
     Map<String, Object> queryParams
     Map<String, Object> body
 
     static constraints = {
         url nullable: false, url: ['localhost:\\d*']
-        httpMethod nullable: false, inList: [HttpMethod.GET.name(), HttpMethod.PUT.name(), HttpMethod.POST.name(), HttpMethod.DELETE.name(), HttpMethod.HEAD.name()]
+        httpMethod nullable: false
+        contentType nullable: false
         headers nullable: true
         queryParams nullable: true
         body nullable: true
@@ -31,6 +34,7 @@ class MessageCommand implements Validateable {
         [
                 url: url,
                 httpMethod: httpMethod,
+                contentType: contentType,
                 headers: headers,
                 queryParams: queryParams,
                 body: body

--- a/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/utils/RestUtils.groovy
+++ b/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/utils/RestUtils.groovy
@@ -1,10 +1,7 @@
 package com.atlasgenetics.hermes.utils
 
 import com.atlasgenetics.hermes.message.MessageCommand
-import grails.plugins.rest.client.RestBuilder
-import grails.plugins.rest.client.RestResponse
-import groovy.transform.CompileStatic
-import org.springframework.http.HttpMethod
+import groovyx.net.http.HTTPBuilder
 
 /**
  * This class houses the actual logic that builds and sends HTTP requests.
@@ -15,13 +12,11 @@ import org.springframework.http.HttpMethod
  *   codes will not be retried
  * - 5xx response codes are treated as failures, but the message itself is still regarded as valid and eligible for
  *   retry
- * - ConnectExceptions thrown by RestBuilder will be treated as 5xx errors for most intents and purposes.  All messages
- *   failing with ConnectExceptions will be saved with status code {@link this.CONNECT_EXCEPTION_CODE} and are eligible
- *   for retry
+ * - ConnectExceptions will be treated as 5xx errors for most intents and purposes.  All messages failing with
+ *   ConnectExceptions will be saved with status code {@link this.CONNECT_EXCEPTION_CODE} and are eligible for retry
  *
  * @author Maura Warner
  */
-@CompileStatic
 class RestUtils {
 
     /**
@@ -37,11 +32,7 @@ class RestUtils {
      * @return the HTTP status code of the response
      */
     static int attemptInitialSend(MessageCommand message) {
-        try {
-            return makeRequest(message)
-        } catch (ConnectException e) {
-            return CONNECT_EXCEPTION_CODE
-        }
+        return makeRequest(message)
     }
 
     /**
@@ -60,7 +51,7 @@ class RestUtils {
     }
 
     static boolean isFailureCode(int statusCode) {
-        300 <= statusCode || statusCode == 0
+        300 <= statusCode || statusCode == CONNECT_EXCEPTION_CODE
     }
 
     static boolean isInvalidMessageCode(int statusCode) {
@@ -72,82 +63,24 @@ class RestUtils {
     }
 
     private static int makeRequest(MessageCommand messageData) {
-        switch (messageData.httpMethod as HttpMethod) {
-            case HttpMethod.POST:
-                return doPost(messageData)
-            case HttpMethod.GET:
-                return doGet(messageData)
-            case HttpMethod.PUT:
-                return doPut(messageData)
-            case HttpMethod.DELETE:
-                return doDelete(messageData)
-            case HttpMethod.HEAD:
-                return doHead(messageData)
-            default:
-                throw new IllegalArgumentException("HTTP method ${messageData.httpMethod} not supported")
+        try {
+            int responseStatus
+            HTTPBuilder http = new HTTPBuilder()
+            http.request(messageData.fullUrl, messageData.httpMethod, messageData.contentType) {
+                if (messageData.headers) headers = messageData.headers
+                if (messageData.body) body = messageData.body
+
+                response.success = { resp ->
+                    responseStatus = resp.status
+                }
+
+                response.failure = { resp ->
+                    responseStatus = resp.status
+                }
+            }
+            return responseStatus
+        } catch (ConnectException e) {
+            return CONNECT_EXCEPTION_CODE
         }
     }
-
-    private static int doPost(MessageCommand messageData) {
-        RestBuilder rest = new RestBuilder()
-        RestResponse resp = rest.post(messageData.fullUrl) {
-            Map<String, String> headerData = messageData.headers as Map<String, String>
-            headerData?.each { k, v ->
-                header(k, v)
-            }
-            json {
-                messageData.body
-            }
-        }
-        return resp.status
-    }
-
-    private static int doGet(MessageCommand messageData) {
-        RestBuilder rest = new RestBuilder()
-        RestResponse resp = rest.get(messageData.fullUrl) {
-            Map<String, String> headerData = messageData.headers as Map<String, String>
-            headerData?.each { k, v ->
-                header(k, v)
-            }
-        }
-        return resp.status
-    }
-
-    private static int doPut(MessageCommand messageData) {
-        RestBuilder rest = new RestBuilder()
-        RestResponse resp = rest.put(messageData.fullUrl) {
-            Map<String, String> headerData = messageData.headers as Map<String, String>
-            headerData?.each { k, v ->
-                header(k, v)
-            }
-            json {
-                messageData.body
-            }
-        }
-        return resp.status
-
-    }
-
-    private static int doDelete(MessageCommand messageData) {
-        RestBuilder rest = new RestBuilder()
-        RestResponse resp = rest.delete(messageData.fullUrl) {
-            Map<String, String> headerData = messageData.headers as Map<String, String>
-            headerData?.each { k, v ->
-                header(k, v)
-            }
-        }
-        return resp.status
-    }
-
-    private static int doHead(MessageCommand messageData) {
-        RestBuilder rest = new RestBuilder()
-        RestResponse resp = rest.head(messageData.fullUrl) {
-            Map<String, String> headerData = messageData.headers as Map<String, String>
-            headerData?.each { k, v ->
-                header(k, v)
-            }
-        }
-        return resp.status
-    }
-
 }

--- a/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/message/MessageCommandSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/message/MessageCommandSpec.groovy
@@ -1,8 +1,10 @@
 package com.atlasgenetics.hermes.message
 
-import org.springframework.http.HttpMethod
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import spock.lang.Specification
 import spock.lang.Unroll
+
 
 class MessageCommandSpec extends Specification {
 
@@ -29,7 +31,8 @@ class MessageCommandSpec extends Specification {
     void "test toMap"() {
         given: "a MessageCommand"
         MessageCommand command = new MessageCommand()
-        command.httpMethod = HttpMethod.GET
+        command.httpMethod = Method.GET
+        command.contentType = ContentType.JSON
         command.url = "http://www.test.example.com/endpoint/val"
         command.queryParams = [param: "value"]
         command.headers = [header: "data"]
@@ -40,6 +43,7 @@ class MessageCommandSpec extends Specification {
         then: "all the data is preserved as expected"
         map.httpMethod == command.httpMethod
         map.url == command.url
+        map.contentType == command.contentType
         map.queryParams == command.queryParams
         map.headers == command.headers
 
@@ -48,6 +52,7 @@ class MessageCommandSpec extends Specification {
 
         then: "all the data transfers back smoothly"
         newCommand.httpMethod == command.httpMethod
+        newCommand.contentType == command.contentType
         newCommand.queryParams == command.queryParams
         newCommand.headers == command.headers
         newCommand.fullUrl == command.fullUrl

--- a/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/message/MessageCommandSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/message/MessageCommandSpec.groovy
@@ -5,7 +5,6 @@ import groovyx.net.http.Method
 import spock.lang.Specification
 import spock.lang.Unroll
 
-
 class MessageCommandSpec extends Specification {
 
     @Unroll("test buildUri with expected output #expected")

--- a/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/utils/RestUtilsSpec.groovy
+++ b/hermes-plugin/src/test/groovy/com/atlasgenetics/hermes/utils/RestUtilsSpec.groovy
@@ -1,10 +1,11 @@
 package com.atlasgenetics.hermes.utils
 
 import com.atlasgenetics.hermes.message.MessageCommand
-import com.stehno.ersatz.ContentType
+import com.stehno.ersatz.ContentType as ErsatzContentType
 import com.stehno.ersatz.Decoders
 import com.stehno.ersatz.ErsatzServer
-import org.springframework.http.HttpMethod
+import groovyx.net.http.ContentType
+import groovyx.net.http.Method
 import org.springframework.http.HttpStatus
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -91,7 +92,7 @@ class RestUtilsSpec extends Specification {
         }
 
         and: "a message messageData object"
-        MessageCommand messageData = buildMessageData(HttpMethod.GET, mock.httpUrl)
+        MessageCommand messageData = buildMessageData(Method.GET, mock.httpUrl)
 
         when: "the request is sent"
         int status = RestUtils.attemptInitialSend(messageData)
@@ -107,7 +108,7 @@ class RestUtilsSpec extends Specification {
             put(TEST_URI) {
                 query QUERY_KEY, QUERY_VAL
                 header HEADER_KEY, HEADER_VAL
-                body BODY, ContentType.APPLICATION_JSON.value
+                body BODY, ErsatzContentType.APPLICATION_JSON.value
 
                 responder {
                     code HttpStatus.OK.value()
@@ -118,7 +119,7 @@ class RestUtilsSpec extends Specification {
         }
 
         and: "a message messageData object"
-        MessageCommand messageData = buildMessageData(HttpMethod.PUT, mock.httpUrl)
+        MessageCommand messageData = buildMessageData(Method.PUT, mock.httpUrl)
 
         when: "the request is sent"
         int status = RestUtils.attemptInitialSend(messageData)
@@ -134,7 +135,7 @@ class RestUtilsSpec extends Specification {
             post(TEST_URI) {
                 query QUERY_KEY, QUERY_VAL
                 header HEADER_KEY, HEADER_VAL
-                body BODY, ContentType.APPLICATION_JSON.value
+                body BODY, ErsatzContentType.APPLICATION_JSON.value
 
                 responder {
                     code HttpStatus.OK.value()
@@ -145,7 +146,7 @@ class RestUtilsSpec extends Specification {
         }
 
         and: "a message messageData object"
-        MessageCommand messageData = buildMessageData(HttpMethod.POST, mock.httpUrl)
+        MessageCommand messageData = buildMessageData(Method.POST, mock.httpUrl)
 
         when: "the request is sent"
         int status = RestUtils.attemptInitialSend(messageData)
@@ -171,7 +172,7 @@ class RestUtilsSpec extends Specification {
         }
 
         and: "a message messageData object"
-        MessageCommand messageData = buildMessageData(HttpMethod.DELETE, mock.httpUrl)
+        MessageCommand messageData = buildMessageData(Method.DELETE, mock.httpUrl)
 
         when: "the request is sent"
         int status = RestUtils.attemptInitialSend(messageData)
@@ -197,7 +198,7 @@ class RestUtilsSpec extends Specification {
         }
 
         and: "a message messageData object"
-        MessageCommand messageData = buildMessageData(HttpMethod.HEAD, mock.httpUrl)
+        MessageCommand messageData = buildMessageData(Method.HEAD, mock.httpUrl)
 
         when: "the request is sent"
         int status = RestUtils.attemptInitialSend(messageData)
@@ -206,7 +207,7 @@ class RestUtilsSpec extends Specification {
         status == HttpStatus.OK.value()
     }
 
-    private static MessageCommand buildMessageData(HttpMethod method, String baseUrl) {
+    private static MessageCommand buildMessageData(Method method, String baseUrl) {
         def headers = [:]
         headers[HEADER_KEY] = HEADER_VAL
         def queryParams = [:]
@@ -215,9 +216,10 @@ class RestUtilsSpec extends Specification {
         MessageCommand command = new MessageCommand()
         command.url = "$baseUrl$TEST_URI"
         command.headers = headers
+        command.contentType = ContentType.JSON
         command.queryParams = queryParams
-        command.body = BODY
-        command.httpMethod = method.name()
+        if (method in [Method.PUT, Method.POST]) command.body = BODY
+        command.httpMethod = method
         return command
     }
 
@@ -228,7 +230,7 @@ class RestUtilsSpec extends Specification {
      */
     private static ErsatzServer newErsatzServer() {
         ErsatzServer mock = new ErsatzServer()
-        mock.decoder(ContentType.APPLICATION_JSON.value, Decoders.parseJson)
+        mock.decoder(ErsatzContentType.APPLICATION_JSON.value, Decoders.parseJson)
         return mock
     }
 


### PR DESCRIPTION
The PWN API expects XML request bodies.  Hermes was initially written to only support JSON, because everyone managed to forget that.

Changes:

* Finally caved and switched to `HTTPBuilder` in `RestUtils`, which is much more generic, at the cost of the `@CompileStatic` annotation
* Added `contentType` to `MessageCommand`
* Updated tests
* Updated README and JavaDoc comments
* Incremented plugin version number