### PR TITLE
[ch472] Make request body more generic

### DIFF
--- a/hermes-plugin/build.gradle
+++ b/hermes-plugin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version "1.3"
+version "1.3.1"
 group "com.atlasgenetics"
 
 apply plugin:"eclipse"

--- a/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
+++ b/hermes-plugin/grails-app/services/com/atlasgenetics/hermes/message/HermesService.groovy
@@ -52,9 +52,9 @@ class HermesService {
      * @param body
      * @return the last response received while attempting to send the message
      */
-    HermesResponseWrapper makeRequest(Method httpMethod, String url, ContentType contentType, Map<String, Object> metadata = null,
+    HermesResponseWrapper makeRequest(Method httpMethod, String url, ContentType contentType, def metadata = null,
                                       Map<String, Object> headers = null, Map<String, Object> queryParams = null,
-                                      Map<String, Object> body = null) {
+                                      def body = null) {
         MessageCommand messageCommand = new MessageCommand()
         messageCommand.httpMethod = httpMethod
         messageCommand.url = url

--- a/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/HermesGrailsPlugin.groovy
+++ b/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/HermesGrailsPlugin.groovy
@@ -16,7 +16,7 @@ An HTTP messenger that sends REST requests to third party APIs with guaranteed o
     def profiles = ['web']
 
     // URL to the plugin's documentation
-    def documentation = "https://github.com/atlasgenetics/hermes/blob/master/hermes-plugin/README.md"
+    def documentation = "https://github.com/atlasgenetics/hermes/blob/master/README.md"
 
     // Details of company behind the plugin (if there is one)
     def organization = [ name: "Atlas Genetics", url: "http://atlasgenetics.com" ]

--- a/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/message/MessageCommand.groovy
+++ b/hermes-plugin/src/main/groovy/com/atlasgenetics/hermes/message/MessageCommand.groovy
@@ -15,8 +15,8 @@ class MessageCommand implements Validateable {
     ContentType contentType
     Map<String, Object> headers
     Map<String, Object> queryParams
-    Map<String, Object> body
-    Map<String, Object> metadata
+    def body
+    def metadata
 
     static constraints = {
         url nullable: false, url: ['localhost:\\d*']


### PR DESCRIPTION
Changed the `body` param on `MessageCommand` to `def`.  Also changed the `metadata` param to `def` since there's no need to do any kind of type enforcement on it.

I also updated the plugin configuration to point to the right README file, so the updated README I wrote will actually show up in Bintray.